### PR TITLE
combat aware familiar.drac

### DIFF
--- a/familiar.drac
+++ b/familiar.drac
@@ -64,6 +64,8 @@ if 'name' in familiar:
     title = f'-title "{familiar.name} makes a [cname] check!"'
 if 'image' in familiar:
     image = f'-thumb {familiar.image}'
+if combat() and familiar.get('name') and combat().get_combatant(familiar.name):
+    return f'''i oc {familiar.name} %1% {title} {image}'''
 return f'''mc "{familiar.type}" %1% {title} {image}'''
 </drac2>
 
@@ -80,6 +82,8 @@ if 'name' in familiar:
     title = f'-title "{familiar.name} makes a [sname]!"'
 if 'image' in familiar:
     image = f'-thumb {familiar.image}'
+if combat() and familiar.get('name') and combat().get_combatant(familiar.name):
+    return f'''i os {familiar.name} %1% {title} {image}'''
 return f'''ms "{familiar.type}" %1% {title} {image}'''
 </drac2>
 
@@ -96,6 +100,8 @@ if 'name' in familiar:
     title = f'-title "{familiar.name} attacks with [aname]!"'
 if 'image' in familiar:
     image = f'-thumb {familiar.image}'
+if combat() and familiar.get('name') and combat().get_combatant(familiar.name):
+    return f'''i oa {familiar.name} %1% {title} {image}'''
 return f'''ma "{familiar.type}" %1% {title} {image}'''
 </drac2>
 


### PR DESCRIPTION
`!fa`, `!fc` and `!fs` will use the combatant rather than a generic monster for these actions to leverage effect tracking while in combat.